### PR TITLE
fix logic bug in checking for network in hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,7 @@ const getAccounts = (network: string) => {
     testnet: [process.env.TESTNET_ACCOUNT_PRIVATE_KEY],
   };
 
-  if (!!accounts[network]) {
+  if (!accounts[network]) {
     throw new Error(`Your account environment variables for ${network} are not set`);
   }
 


### PR DESCRIPTION
Problem:
There was a logic but in checking for the correct network in the hardhat config that was forcing a true condition when we were looking for a false condition.

Solution:
Fix the condition to check for false.