### PR TITLE
Feature/registry eip712 methods 177986528

### DIFF
--- a/contracts/IRegistry.sol
+++ b/contracts/IRegistry.sol
@@ -123,5 +123,5 @@ interface IRegistry {
      *
      * @return nonce value for handle
      */
-    function resolveHandleToNonce(string calldata handle) external view returns (uint64);
+    function resolveHandleToNonce(string calldata handle) external view returns (uint32);
 }

--- a/contracts/IRegistry.sol
+++ b/contracts/IRegistry.sol
@@ -32,6 +32,7 @@ interface IRegistry {
      * @dev Register a new DSNP Id
      * @param addr Address for the new DSNP Id to point at
      * @param handle The handle for discovery
+     * @return id for new registration
      *
      * MUST reject if the handle is already in use
      * MUST emit DSNPRegistryUpdate

--- a/contracts/IRegistry.sol
+++ b/contracts/IRegistry.sol
@@ -8,6 +8,18 @@ pragma solidity >=0.8.0 <0.9.0;
  *   mapping(string => [id, address]) internal handleToIdAndAddress;
  */
 interface IRegistry {
+    struct AddressChange {
+        uint32 nonce;
+        address addr;
+        string handle;
+    }
+
+    struct HandleChange {
+        uint32 nonce;
+        string oldHandle;
+        string newHandle;
+    }
+
     /**
      * @dev Log when a resolution address is changed
      * @param id The DSNP Id
@@ -22,9 +34,8 @@ interface IRegistry {
      * @param handle The handle for discovery
      *
      * MUST reject if the handle is already in use
-     * MUST be called by someone who is authorized on the contract
-     *      via `IDelegation(addr).isAuthorizedTo(msg.sender, Permission.OWNERSHIP_TRANSFER, block.number)`
      * MUST emit DSNPRegistryUpdate
+     * MUST check that addr implements IDelegation interface
      */
     function register(address addr, string calldata handle) external returns (uint64);
 
@@ -36,8 +47,28 @@ interface IRegistry {
      * MUST be called by someone who is authorized on the contract
      *      via `IDelegation(oldAddr).isAuthorizedTo(oldAddr, Permission.OWNERSHIP_TRANSFER, block.number)`
      * MUST emit DSNPRegistryUpdate
+     * MUST check that addr implements IDelegation interface
      */
     function changeAddress(address newAddr, string calldata handle) external;
+
+    /**
+     * @dev Alter a DSNP Id resolution address by EIP-712 Signature
+     * @param v EIP-155 calculated Signature v value
+     * @param r ECDSA Signature r value
+     * @param s ECDSA Signature s value
+     * @param change Change data containing nonce, new address and handle
+     *
+     * MUST be signed by someone who is authorized on the contract
+     *      via `IDelegation(oldAddr).isAuthorizedTo(ecrecovedAddr, Permission.OWNERSHIP_TRANSFER, block.number)`
+     * MUST check that newAddr implements IDelegation interface
+     * MUST emit DSNPRegistryUpdate
+     */
+    function changeAddressByEIP712Sig(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        AddressChange calldata change
+    ) external;
 
     /**
      * @dev Alter a DSNP Id handle
@@ -50,6 +81,25 @@ interface IRegistry {
      * MUST emit DSNPRegistryUpdate
      */
     function changeHandle(string calldata oldHandle, string calldata newHandle) external;
+
+    /**
+     * @dev Alter a DSNP Id handle by EIP-712 Signature
+     * @param v EIP-155 calculated Signature v value
+     * @param r ECDSA Signature r value
+     * @param s ECDSA Signature s value
+     * @param change Change data containing nonce, old handle and new handle
+     *
+     * MUST NOT allow a registration of a handle that is already in use
+     * MUST be signed by someone who is authorized on the contract
+     *      via `IDelegation(handle -> addr).isAuthorizedTo(ecrecovedAddr, Permission.OWNERSHIP_TRANSFER, block.number)`
+     * MUST emit DSNPRegistryUpdate
+     */
+    function changeHandleByEIP712Sig(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        HandleChange calldata change
+    ) external;
 
     /**
      * @dev Resolve a handle to a contract address
@@ -66,4 +116,12 @@ interface IRegistry {
      * @return DSNP Id
      */
     function resolveHandleToId(string calldata handle) external view returns (uint64);
+
+    /**
+     * @dev Resolve a handle to nonce
+     * @param handle The handle to resolve
+     *
+     * @return nonce value for handle
+     */
+    function resolveHandleToNonce(string calldata handle) external view returns (uint64);
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -347,7 +347,7 @@ contract Registry is IRegistry {
         uint8 v,
         bytes32 r,
         bytes32 s,
-        HandleChange memory change
+        HandleChange calldata change
     ) internal view returns (address) {
         bytes32 typeHash =
             keccak256(

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -14,14 +14,46 @@ contract Registry is IRegistry {
             IDelegation.delegateRemoveByEIP712Sig.selector ^
             IDelegation.isAuthorizedTo.selector;
 
+    string private constant ADDRESS_CHANGE_TYPE =
+        "AddressChange(uint32 nonce,address addr,string handle)";
+    bytes32 private constant ADDRESS_CHANGE_TYPEHASH =
+        keccak256(abi.encodePacked(ADDRESS_CHANGE_TYPE));
+    string private constant HANDLE_CHANGE_TYPE =
+        "HandleChange(uint32 nonce,string oldHandle,string newHandle)";
+    bytes32 private constant HANDLE_CHANGE_TYPEHASH =
+        keccak256(abi.encodePacked(HANDLE_CHANGE_TYPE));
+
+    string private constant EIP712_DOMAIN =
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)";
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH = keccak256(abi.encodePacked(EIP712_DOMAIN));
+    bytes32 private constant SALT =
+        0x01597239a39b73c524db27009bfe992afd78e195ca64846a6fa0ce65ce37b2df;
+
+    bytes32 private domainSeparatorHash;
+
     // Id and identity contract address to be mapped to handle
     struct Registration {
+        uint64 nonce;
         uint64 id;
         address identityAddress;
     }
 
     // Map from handle to registration
     mapping(string => Registration) private registrations;
+
+    // Create domain separator on construction
+    constructor() {
+        domainSeparatorHash = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256("Registry"),
+                keccak256("1"),
+                block.chainid,
+                address(this),
+                SALT
+            )
+        );
+    }
 
     /**
      * @dev Register a new DSNP Id
@@ -39,7 +71,6 @@ contract Registry is IRegistry {
 
         // Set id to latest sequence number then increment
         reg.id = idSequence++;
-
         reg.identityAddress = addr;
 
         // emit registration event
@@ -95,6 +126,53 @@ contract Registry is IRegistry {
     }
 
     /**
+     * @dev Alter a DSNP Id resolution address by EIP-712 Signature
+     * @param v EIP-155 calculated Signature v value
+     * @param r ECDSA Signature r value
+     * @param s ECDSA Signature s value
+     * @param change Change data containing nonce, new address and handle
+     */
+    function changeAddressByEIP712Sig(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        AddressChange calldata change
+    ) external override {
+        // Checks
+
+        Registration storage reg = registrations[change.handle];
+        require(reg.id != 0, "Handle does not exist");
+        require(reg.nonce == change.nonce, "Nonces do not match");
+
+
+        address signer = addressChangeSigner(v, r, s, change);
+
+        // Effects
+
+        reg.nonce++;
+
+        address oldAddr = reg.identityAddress;
+        reg.identityAddress = change.addr;
+        emit DSNPRegistryUpdate(reg.id, change.addr, change.handle);
+
+        // Interactions
+
+        // ensure old delegation contract authorizes this change
+        IDelegation oldAuth = IDelegation(oldAddr);
+        require(
+            oldAuth.isAuthorizedTo(signer, IDelegation.Permission.OWNERSHIP_TRANSFER, block.number),
+            "Access denied"
+        );
+
+        // ensure new delegation contract implements IDelegation interface
+        ERC165 delegation = ERC165(change.addr);
+        require(
+            delegation.supportsInterface(IDELEGATION_SIG),
+            "contract does not support IDelegation interface"
+        );
+    }
+
+    /**
      * @dev Alter a DSNP Id handle
      * @param oldHandle The previous handle for modification
      * @param newHandle The new handle to use for discovery
@@ -134,6 +212,54 @@ contract Registry is IRegistry {
     }
 
     /**
+     * @dev Alter a DSNP Id handle by EIP-712 Signature
+     * @param v EIP-155 calculated Signature v value
+     * @param r ECDSA Signature r value
+     * @param s ECDSA Signature s value
+     * @param change Change data containing nonce, old handle and new handle
+     */
+    function changeHandleByEIP712Sig(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        HandleChange calldata change
+    ) external override {
+        // Checks
+
+        Registration storage oldReg = registrations[change.oldHandle];
+        require(oldReg.id != 0, "Old handle does not exist");
+
+        Registration storage newReg = registrations[change.newHandle];
+        require(newReg.id == 0, "New handle already exists");
+
+        address signer = handleChangeSigner(v, r, s, change);
+
+        // Effects
+
+        // assign to new registration
+        newReg.id = oldReg.id;
+        newReg.identityAddress = oldReg.identityAddress;
+
+        // signal that the old handle is unassigned and available
+        oldReg.id = 0;
+
+        // notify the change
+        emit DSNPRegistryUpdate(newReg.id, newReg.identityAddress, change.newHandle);
+
+        // Interactions
+
+        IDelegation authorization = IDelegation(oldReg.identityAddress);
+        require(
+            authorization.isAuthorizedTo(
+                signer,
+                IDelegation.Permission.OWNERSHIP_TRANSFER,
+                block.number
+            ),
+            "Access denied"
+        );
+    }
+
+    /**
      * @dev Resolve a handle to a contract address
      * @param handle The handle to resolve
      *
@@ -164,5 +290,61 @@ contract Registry is IRegistry {
         require(reg.id != 0, "Handle does not exist");
 
         return reg.id;
+    }
+
+    /**
+     * @dev Resolve a handle to nonce
+     * @param handle The handle to resolve
+     *
+     * @return nonce value for handle
+     */
+    function resolveHandleToNonce(string calldata handle) external view override returns (uint64) {
+        Registration memory reg = registrations[handle];
+
+        require(reg.id != 0, "Handle does not exist");
+
+        return reg.nonce;
+    }
+
+    function addressChangeSigner(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        AddressChange memory change
+    ) internal view returns (address) {
+        bytes memory encoded = abi.encode(
+            ADDRESS_CHANGE_TYPEHASH,
+            change.nonce,
+            change.addr,
+            keccak256(bytes(change.handle))
+        );
+        return signerFromHashStruct(v, r, s, encoded);
+    }
+
+    function handleChangeSigner(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        HandleChange memory change
+    ) internal view returns (address) {
+        bytes memory encoded = abi.encode(
+            HANDLE_CHANGE_TYPEHASH,
+            change.nonce,
+            keccak256(bytes(change.oldHandle)),
+            keccak256(bytes(change.newHandle))
+        );
+        return signerFromHashStruct(v, r, s, encoded);
+    }
+
+    function signerFromHashStruct(
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes memory hashStruct
+    ) internal view returns (address) {
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", domainSeparatorHash, keccak256(hashStruct))
+        );
+        return ecrecover(digest, v, r, s);
     }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -29,7 +29,7 @@ contract Registry is IRegistry {
     bytes32 private constant SALT =
         0x01597239a39b73c524db27009bfe992afd78e195ca64846a6fa0ce65ce37b2df;
 
-    bytes32 private domainSeparatorHash;
+    bytes32 private immutable domainSeparatorHash;
 
     // Id and identity contract address to be mapped to handle
     struct Registration {
@@ -301,7 +301,7 @@ contract Registry is IRegistry {
      *
      * @return nonce value for handle
      */
-    function resolveHandleToNonce(string calldata handle) external view override returns (uint64) {
+    function resolveHandleToNonce(string calldata handle) external view override returns (uint32) {
         Registration memory reg = registrations[handle];
 
         require(reg.id != 0, "Handle does not exist");

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -321,7 +321,7 @@ contract Registry is IRegistry {
         uint8 v,
         bytes32 r,
         bytes32 s,
-        AddressChange memory change
+        AddressChange calldata change
     ) internal view returns (address) {
         bytes32 typeHash =
             keccak256(

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -33,7 +33,7 @@ contract Registry is IRegistry {
 
     // Id and identity contract address to be mapped to handle
     struct Registration {
-        uint64 nonce;
+        uint32 nonce;
         uint64 id;
         address identityAddress;
     }

--- a/test/EIP712.ts
+++ b/test/EIP712.ts
@@ -1,0 +1,173 @@
+import { ethers } from "hardhat";
+
+type EIP712Signature = { r: string; s: string; v: string };
+
+export const signEIP712 = async (signer, domain, types, message): Promise<EIP712Signature> => {
+  const sig = await signer._signTypedData(domain, types, message);
+  return {
+    r: "0x" + sig.substring(2).substring(0, 64),
+    s: "0x" + sig.substring(2).substring(64, 128),
+    v: "0x" + sig.substring(2).substring(128, 130),
+  };
+};
+
+// The following functions should only be used for debugging
+
+function abiRawEncode(types: ReadonlyArray<string>, values: ReadonlyArray<any>): Buffer {
+  const hexStr = ethers.utils.defaultAbiCoder.encode(types, values);
+  return Buffer.from(hexStr.slice(2, hexStr.length), "hex");
+}
+
+function keccak256(arg): Buffer {
+  const hexStr = ethers.utils.keccak256(arg);
+  return Buffer.from(hexStr.slice(2, hexStr.length), "hex");
+}
+
+type ValueType = { name: string; type: string };
+type StructType = Array<ValueType>;
+type TypeDeclaration = { [property: string]: StructType };
+
+// Recursively finds all the dependencies of a type
+function dependencies(primaryType: string, found: Array<string> = [], types: TypeDeclaration = {}) {
+  if (found.includes(primaryType)) {
+    return found;
+  }
+  if (types[primaryType] === undefined) {
+    return found;
+  }
+  found.push(primaryType);
+  for (let field of types[primaryType]) {
+    for (let dep of dependencies(field.type, found)) {
+      if (!found.includes(dep)) {
+        found.push(dep);
+      }
+    }
+  }
+  return found;
+}
+
+export function encodeType(primaryType: string, types: TypeDeclaration = {}): string {
+  // Get dependencies primary first, then alphabetical
+  let deps = dependencies(primaryType);
+  deps = deps.filter((t) => t != primaryType);
+  deps = [primaryType].concat(deps.sort());
+
+  // Format as a string with fields
+  let result = "";
+  for (let type of deps) {
+    if (!types[type])
+      throw new Error(`Type '${type}' not defined in types (${JSON.stringify(types)})`);
+    result += `${type}(${types[type].map(({ name, type }) => `${type} ${name}`).join(",")})`;
+  }
+  return result;
+}
+
+export function typeHash(primaryType: string, types: TypeDeclaration = {}): Buffer {
+  return keccak256(Buffer.from(encodeType(primaryType, types)));
+}
+
+export function encodeData(
+  primaryType: string,
+  data: Record<string, any>,
+  types: TypeDeclaration = {}
+): Buffer {
+  let encTypes: Array<string> = [];
+  let encValues: Array<Buffer> = [];
+
+  // Add typehash
+  encTypes.push("bytes32");
+  encValues.push(typeHash(primaryType, types));
+
+  // Add field contents
+  for (let field of types[primaryType]) {
+    let value = data[field.name];
+    if (field.type == "string" || field.type == "bytes") {
+      encTypes.push("bytes32");
+      value = keccak256(Buffer.from(value));
+      encValues.push(value);
+    } else if (types[field.type] !== undefined) {
+      encTypes.push("bytes32");
+      value = keccak256(encodeData(field.type, value, types));
+      encValues.push(value);
+    } else if (field.type.lastIndexOf("]") === field.type.length - 1) {
+      throw "TODO: Arrays currently unimplemented in encodeData";
+    } else {
+      encTypes.push(field.type);
+      encValues.push(value);
+    }
+  }
+
+  return abiRawEncode(encTypes, encValues);
+}
+
+export function domainSeparator(domain: Record<string, any>): Buffer {
+  const types = {
+    EIP712Domain: [
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+      { name: "salt", type: "bytes32" },
+    ].filter((a) => domain[a.name]),
+  };
+  return keccak256(encodeData("EIP712Domain", domain, types));
+}
+
+function structHash(
+  primaryType: string,
+  data: Record<string, any>,
+  types: TypeDeclaration = {}
+): Buffer {
+  return keccak256(encodeData(primaryType, data, types));
+}
+
+export function digestToSign(
+  domain: Record<string, any>,
+  primaryType: string,
+  message: Record<string, any>,
+  types: TypeDeclaration = {}
+): Buffer {
+  return keccak256(
+    Buffer.concat([
+      Buffer.from("1901", "hex"),
+      domainSeparator(domain),
+      structHash(primaryType, message, types),
+    ])
+  );
+}
+
+async function sign(
+  domain: Record<string, any>,
+  primaryType: string,
+  message: Record<string, any>,
+  types: TypeDeclaration = {},
+  signer: any
+): Promise<Record<string, string>> {
+  let signature;
+
+  try {
+    if (signer._signingKey) {
+      const digest = digestToSign(domain, primaryType, message, types);
+      signature = signer._signingKey().signDigest(digest);
+      signature.v = "0x" + signature.v.toString(16);
+    } else {
+      const address = await signer.getAddress();
+      const msgParams = JSON.stringify({ domain, primaryType, message, types });
+
+      signature = await signer.provider.jsonRpcFetchFunc("eth_signTypedData_v4", [
+        address,
+        msgParams,
+      ]);
+
+      const r = "0x" + signature.substring(2).substring(0, 64);
+      const s = "0x" + signature.substring(2).substring(64, 128);
+      const v = "0x" + signature.substring(2).substring(128, 130);
+
+      signature = { r, s, v };
+    }
+  } catch (e) {
+    throw new Error(e);
+  }
+
+  return signature;
+}

--- a/test/Registry.test.ts
+++ b/test/Registry.test.ts
@@ -255,8 +255,8 @@ describe("Registry", () => {
   });
 
   describe("changeHandle", async () => {
-     // create registration to change
-     beforeEach(async () => {
+    // create registration to change
+    beforeEach(async () => {
       await registry.connect(signer1).register(delegate1.address, handle);
     });
 
@@ -293,9 +293,9 @@ describe("Registry", () => {
     });
 
     it("reverts when handle does not exist", async () => {
-      await expect(registry.connect(signer1).changeHandle("notahandle", newHandle)).to.be.revertedWith(
-        "Old handle does not exist"
-      );
+      await expect(
+        registry.connect(signer1).changeHandle("notahandle", newHandle)
+      ).to.be.revertedWith("Old handle does not exist");
     });
 
     it("reverts when new handle already exists", async () => {
@@ -354,7 +354,7 @@ describe("Registry", () => {
       await registry.connect(signer2).changeHandleByEIP712Sig(v, r, s, message);
 
       // we must register handle again to retrieve its nonce
-      await registry.connect(signer2).register(delegate2.address, handle)
+      await registry.connect(signer2).register(delegate2.address, handle);
 
       expect(await registry.resolveHandleToNonce(handle)).to.equal(1);
     });
@@ -375,7 +375,7 @@ describe("Registry", () => {
       await registry.connect(signer2).changeHandleByEIP712Sig(v, r, s, message);
 
       // we must register handle again before we update it
-      await registry.connect(signer2).register(delegate2.address, handle)
+      await registry.connect(signer2).register(delegate2.address, handle);
 
       // create an EIP 712 handle change that should fail with nonce=0
       const message2 = { nonce: 0, oldHandle: handle, newHandle: "yetanotherhandle" };


### PR DESCRIPTION
Problem
=======
We want Registry users to make registry changes through a 3rd party who can cover the costs of the transaction. EIP 712 signed messages provide a mechanism to do this securely.
[link to Pivotal Tracker #177986528](https://www.pivotaltracker.com/story/show/177986528)

Solution
========
This PR adds implementations of `changeAddressByEIP712Sig` and `changeHandleByEIP712Sig` to the `Registry` contract.  It also adds some test infrastructure.

Change summary:
---------------
* Add logic to compute domain separator in Registry constructor.
* Add logic to compute type hashes of `AddressChange` and `HandleChange` structs in `Registry`.
* Add logic to recover an address from the domain hash, a type hash and an EIP 712 signature.
* Add `changeAddressByEIP712Sig` that has all the logic of `changeAddress` but also recovers address from signature and uses it to authorize. It also checks and increments nonce stored under the handle that was introduced this PR.
* Add `changeHandleByEIP712Sig` that has all the logic of `changeHandle` but also recovers address from signature and uses it to authorize. It also checks and increments nonce.
