### PR TITLE
Correct the version of test-generators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ethersproject/contracts": "^5.1.1"
       },
       "devDependencies": {
-        "@dsnp/test-generators": "next",
+        "@dsnp/test-generators": "0.0.0-6a23bc",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@typechain/ethers-v5": "^6.0.5",
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@dsnp/test-generators": {
-      "version": "0.0.0-c2bad3",
-      "resolved": "https://registry.npmjs.org/@dsnp/test-generators/-/test-generators-0.0.0-c2bad3.tgz",
-      "integrity": "sha512-GadldyQJ4BQzm5gqsktD+oeHHWt/Qz02wPwoiTzOV9E3gUZ1IOMfIJ5aEMN621mEWm6O81ZNT1chjYwUyoCHsw==",
+      "version": "0.0.0-6a23bc",
+      "resolved": "https://registry.npmjs.org/@dsnp/test-generators/-/test-generators-0.0.0-6a23bc.tgz",
+      "integrity": "sha512-bp7dXFrsUqyxtS4bUGYWYY+BhrSB++sJLJPKQjdhtijfP7uUfvLmVvL1mflGnhs/sgkrZJho+UXN27VWm20P5w==",
       "dev": true
     },
     "node_modules/@ensdomains/ens": {
@@ -17302,9 +17302,9 @@
       }
     },
     "@dsnp/test-generators": {
-      "version": "0.0.0-c2bad3",
-      "resolved": "https://registry.npmjs.org/@dsnp/test-generators/-/test-generators-0.0.0-c2bad3.tgz",
-      "integrity": "sha512-GadldyQJ4BQzm5gqsktD+oeHHWt/Qz02wPwoiTzOV9E3gUZ1IOMfIJ5aEMN621mEWm6O81ZNT1chjYwUyoCHsw==",
+      "version": "0.0.0-6a23bc",
+      "resolved": "https://registry.npmjs.org/@dsnp/test-generators/-/test-generators-0.0.0-6a23bc.tgz",
+      "integrity": "sha512-bp7dXFrsUqyxtS4bUGYWYY+BhrSB++sJLJPKQjdhtijfP7uUfvLmVvL1mflGnhs/sgkrZJho+UXN27VWm20P5w==",
       "dev": true
     },
     "@ensdomains/ens": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/Liberty30/contracts#readme",
   "devDependencies": {
-    "@dsnp/test-generators": "next",
+    "@dsnp/test-generators": "0.0.0-6a23bc",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@typechain/ethers-v5": "^6.0.5",


### PR DESCRIPTION
Problem
=======
`@next` flag didn't correctly update the version of the test-generators

Solution
========
Be specific in the version
