### PR TITLE
add createAndRegisterBeaconProxy to beacon factory

### DIFF
--- a/contracts/BeaconFactory.sol
+++ b/contracts/BeaconFactory.sol
@@ -88,19 +88,17 @@ contract BeaconFactory is IIdentityBeaconFactory {
      *
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
      * @dev This must revert if registration reverts
-     * @return The address of the newly created proxy contract and the id of the registration
      */
     function createAndRegisterBeaconProxy(
         address beacon,
         address owner,
         string calldata handle
-    ) external override returns (uint64, address) {
+    ) external override {
         // Create beacon contract
         address addr = this.createBeaconProxyWithOwner(beacon, owner);
 
         // Now register the new contract under the provided handle.
         IRegistry registryContract = IRegistry(registry);
-        uint64 registrationId = registryContract.register(addr, handle);
-        return (registrationId, addr);
+        registryContract.register(addr, handle);
     }
 }

--- a/contracts/BeaconFactory.sol
+++ b/contracts/BeaconFactory.sol
@@ -70,14 +70,7 @@ contract BeaconFactory is IIdentityBeaconFactory {
         override
         returns (address)
     {
-        // Effects
-        IdentityBeaconProxy proxy = new IdentityBeaconProxy();
-        emit ProxyCreated(address(proxy));
-
-        // Interactions
-        proxy.initialize(beacon, owner);
-
-        return address(proxy);
+        return createProxy(beacon, owner);
     }
 
     /**
@@ -94,11 +87,29 @@ contract BeaconFactory is IIdentityBeaconFactory {
         address owner,
         string calldata handle
     ) external override {
-        // Create beacon contract
-        address addr = this.createBeaconProxyWithOwner(beacon, owner);
+        address addr = createProxy(beacon, owner);
 
         // Now register the new contract under the provided handle.
         IRegistry registryContract = IRegistry(registry);
         registryContract.register(addr, handle);
+    }
+
+    /**
+     * @dev Creates a new identity with the ecrecover address as the owner
+     * @param beacon The beacon address to use logic contract resolution
+     * @param owner The initial owner's address of the new contract
+     *
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @return The address of the newly created proxy contract
+     */
+    function createProxy(address beacon, address owner) private returns (address) {
+        // Effects
+        IdentityBeaconProxy proxy = new IdentityBeaconProxy();
+        emit ProxyCreated(address(proxy));
+
+        // Interactions
+        proxy.initialize(beacon, owner);
+
+        return address(proxy);
     }
 }

--- a/contracts/BeaconFactory.sol
+++ b/contracts/BeaconFactory.sol
@@ -74,7 +74,7 @@ contract BeaconFactory is IIdentityBeaconFactory {
     }
 
     /**
-     * @dev Creates a new identity with the adddress as the owner and registers it with a handle
+     * @dev Creates a new identity with the address as the owner and registers it with a handle
      * @param beacon The beacon address to use logic contract resolution
      * @param owner The initial owner's address of the new contract
      * @param handle The handle the new identity proxy under which should be registered

--- a/contracts/IIdentityBeaconFactory.sol
+++ b/contracts/IIdentityBeaconFactory.sol
@@ -46,7 +46,7 @@ interface IIdentityBeaconFactory {
     function createBeaconProxyWithOwner(address beacon, address owner) external returns (address);
 
     /**
-     * @dev Creates a new identity with the adddress as the owner and registers it with a handle
+     * @dev Creates a new identity with the address as the owner and registers it with a handle
      * @param beacon The beacon address to use logic contract resolution
      * @param owner The initial owner's address of the new contract
      * @param handle The handle the new identity proxy under which should be registered

--- a/contracts/IIdentityBeaconFactory.sol
+++ b/contracts/IIdentityBeaconFactory.sol
@@ -53,7 +53,10 @@ interface IIdentityBeaconFactory {
      *
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
      * @dev This must revert if registration reverts
-     * @return The id of the registration and the address of the newly created proxy contract
      */
-    function createAndRegisterBeaconProxy(address beacon, address owner, string calldata handle) external returns (uint64, address);
+    function createAndRegisterBeaconProxy(
+        address beacon,
+        address owner,
+        string calldata handle
+    ) external;
 }

--- a/contracts/IIdentityBeaconFactory.sol
+++ b/contracts/IIdentityBeaconFactory.sol
@@ -44,4 +44,16 @@ interface IIdentityBeaconFactory {
      * @return The address of the newly created proxy contract
      */
     function createBeaconProxyWithOwner(address beacon, address owner) external returns (address);
+
+    /**
+     * @dev Creates a new identity with the adddress as the owner and registers it with a handle
+     * @param beacon The beacon address to use logic contract resolution
+     * @param owner The initial owner's address of the new contract
+     * @param handle The handle the new identity proxy under which should be registered
+     *
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @dev This must revert if registration reverts
+     * @return The id of the registration and the address of the newly created proxy contract
+     */
+    function createAndRegisterBeaconProxy(address beacon, address owner, string calldata handle) external returns (uint64, address);
 }

--- a/scripts/src/deploy.ts
+++ b/scripts/src/deploy.ts
@@ -38,6 +38,15 @@ export async function main() {
   // Emit DSNP migration event for the Identity contract
   await contract1.upgraded(identityLogic.address, "Identity");
 
+  // Deploy the Registry Contract
+  const Registry = await ethers.getContractFactory("Registry");
+  const registry = await Registry.deploy();
+  await registry.deployed();
+  console.log("registry deployed to:", registry.address);
+
+  // Emit DSNP Migration event for the Registry
+  await contract1.upgraded(registry.address, "Registry");
+
   // Deploy the Identity Proxy Clone Factory Contract
   const IdentityCloneFactory = await ethers.getContractFactory("IdentityCloneFactory");
   const cloneFactory = await IdentityCloneFactory.deploy();
@@ -54,20 +63,11 @@ export async function main() {
   console.log("beacon deployed to:", beacon.address);
 
   const IdentityBeaconFactory = await ethers.getContractFactory("BeaconFactory");
-  const beaconFactory = await IdentityBeaconFactory.deploy(beacon.address);
+  const beaconFactory = await IdentityBeaconFactory.deploy(beacon.address, registry.address);
   await beaconFactory.deployed();
   console.log("identity beacon factory logic deployed to:", beaconFactory.address);
 
   // Emit DSNP migration event for the Beacon and factory contract
   await contract1.upgraded(beacon.address, "Beacon");
   await contract1.upgraded(beaconFactory.address, "BeaconFactory");
-
-  // Deploy the Registry Contract
-  const Registry = await ethers.getContractFactory("Registry");
-  const registry = await Registry.deploy();
-  await registry.deployed();
-  console.log("registry deployed to:", registry.address);
-
-  // Emit DSNP Migration event for the Registry
-  await contract1.upgraded(registry.address, "Registry");
 }

--- a/test/BeaconFactory.test.ts
+++ b/test/BeaconFactory.test.ts
@@ -3,6 +3,7 @@ import { ContractTransaction } from "ethers";
 import chai from "chai";
 import { describe } from "mocha";
 import { DelegationPermission, DelegationRole } from "./helpers/DSNPEnums";
+import { keccak256 } from "js-sha3";
 const { expect } = chai;
 
 const getProxyAddressFromResponse = async (response: ContractTransaction) => {
@@ -12,13 +13,47 @@ const getProxyAddressFromResponse = async (response: ContractTransaction) => {
   return events[0]?.args?.addr;
 };
 
+type DSNPRegistryUpdate = {
+  id: number;
+  addr: string;
+  handle: string;
+};
+
+const getDSNPRegistryUpdateFromResponse = async (
+  response: ContractTransaction
+): Promise<DSNPRegistryUpdate> => {
+  const receipt = await response.wait();
+  const Registry = await ethers.getContractFactory("Registry");
+  const regEvents = (l) => {
+    try {
+      return Registry.interface.parseLog(l);
+    } catch {
+      return;
+    }
+  };
+
+  const events =
+    receipt?.events?.map(regEvents).filter((e) => e?.name === "DSNPRegistryUpdate") || [];
+  if (events.length === 0) throw new Error("Unable to find DSNPRegistryUpdate event!");
+  return {
+    id: events[0]?.args[0],
+    addr: events[0]?.args[1],
+    handle: events[0]?.args[2].hash,
+  };
+};
+
 describe("BeaconFactory", () => {
   let factoryInstance, beaconInstance, identityInstance;
   let deployer, signer;
   const noMoneyAddress = "0x0A7D8ED2973c7495E043d5a7fe37684e51Dc707D";
+  const handle = "flarp";
 
   beforeEach(async () => {
     [deployer, signer] = await ethers.getSigners();
+
+    const Registry = await ethers.getContractFactory("Registry");
+    const registry = await Registry.deploy();
+    await registry.deployed();
 
     const Identity = await ethers.getContractFactory("Identity");
     identityInstance = await Identity.deploy("0x0000000000000000000000000000000000000000");
@@ -29,7 +64,7 @@ describe("BeaconFactory", () => {
     await beaconInstance.deployed();
 
     const BeaconFactory = await ethers.getContractFactory("BeaconFactory");
-    factoryInstance = await BeaconFactory.deploy(beaconInstance.address);
+    factoryInstance = await BeaconFactory.deploy(beaconInstance.address, registry.address);
     await factoryInstance.deployed();
   });
 
@@ -145,7 +180,7 @@ describe("BeaconFactory", () => {
       expect(newProxyAddress).to.be.properAddress;
     });
 
-    it("can really is use the TestDelegate Logic", async () => {
+    it("can really use the TestDelegate Logic", async () => {
       // Create a TestDelegate
       const TestDelegate = await ethers.getContractFactory("TestDelegate");
       const testDelegate = await TestDelegate.deploy("0x0000000000000000000000000000000000000000");
@@ -181,6 +216,34 @@ describe("BeaconFactory", () => {
           "0x0"
         )
       ).to.be.true;
+    });
+  });
+
+  describe("createAndRegisterBeaconProxy", () => {
+    it("emits both a ProxyCreated and DSNPRegistryUpdateFromResponse event", async () => {
+      const response = await factoryInstance
+        .connect(signer)
+        .createAndRegisterBeaconProxy(beaconInstance.address, noMoneyAddress, handle);
+      const newProxyAddress = await getProxyAddressFromResponse(response);
+      expect(newProxyAddress).to.be.properAddress;
+
+      const registryEvent = await getDSNPRegistryUpdateFromResponse(response);
+      expect(registryEvent.addr).to.equal(newProxyAddress);
+      expect(registryEvent.handle).to.equal("0x" + keccak256(handle));
+    });
+
+    it("revert in register reverts call", async () => {
+      // make one call that registers handle
+      await factoryInstance
+        .connect(signer)
+        .createAndRegisterBeaconProxy(beaconInstance.address, noMoneyAddress, handle);
+
+      // make another call for different address that attempts to register same handle
+      await expect(
+        factoryInstance
+          .connect(signer)
+          .createAndRegisterBeaconProxy(beaconInstance.address, signer.address, handle)
+      ).to.be.revertedWith("Handle already exists");
     });
   });
 });

--- a/test/IdentityBeaconProxy.test.ts
+++ b/test/IdentityBeaconProxy.test.ts
@@ -22,6 +22,10 @@ describe("IdentityBeaconProxy", () => {
   beforeEach(async () => {
     [deployer, signer] = await ethers.getSigners();
 
+    const Registry = await ethers.getContractFactory("Registry");
+    const registry = await Registry.deploy();
+    await registry.deployed();
+
     const Identity = await ethers.getContractFactory("Identity");
     identityInstance = await Identity.deploy("0x0000000000000000000000000000000000000000");
     await identityInstance.deployed();
@@ -35,7 +39,7 @@ describe("IdentityBeaconProxy", () => {
     await beaconInstance.deployed();
 
     const BeaconFactory = await ethers.getContractFactory("BeaconFactory");
-    beaconFactoryInstance = await BeaconFactory.deploy(beaconInstance.address);
+    beaconFactoryInstance = await BeaconFactory.deploy(beaconInstance.address, registry.address);
     await beaconFactoryInstance.deployed();
   });
 


### PR DESCRIPTION
Problem
=======
Currently, identity contract creation and handle registration are two separate tasks requiring separate transactions. New users will always need to do both. Two sequential transactions means more gas and also requires more state handling on the client to deal with situations where the first transaction succeeds but the second one fails.

Solution
========
This PR introduces a `createAndRegisterBeaconProxy` to the beacon factory that calls `Registry.register()` after it has created the beacon proxy. This permits new user creation with a single transaction.

Change summary:
---------------
* Add reference to registry in `IIdentityBeaconFactory` constructor.
* Modify deployment script and tests to feed registry to `IIdentityBeaconFactory`.
* Add `createAndRegisterBeaconProxy` function.
* Test `createAndRegisterBeaconProxy`.

Steps to Verify:
----------------
1. Inspect code.
2. Run tests.